### PR TITLE
Allow to deserialize to `Option<Vec>`

### DIFF
--- a/src/de/tests.rs
+++ b/src/de/tests.rs
@@ -57,6 +57,18 @@ fn deserialize_option_vec() {
 }
 
 #[test]
+fn deserialize_option_vec_empty() {
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct Form {
+        value: Option<Vec<String>>,
+    }
+
+    let result = super::from_str("");
+
+    assert_eq!(result, Ok(Form { value: None }));
+}
+
+#[test]
 fn deserialize_unit() {
     assert_eq!(super::from_str(""), Ok(()));
     assert_eq!(super::from_str("&"), Ok(()));

--- a/src/de/tests.rs
+++ b/src/de/tests.rs
@@ -45,6 +45,18 @@ fn deserialize_option() {
 }
 
 #[test]
+fn deserialize_option_vec() {
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct Form {
+        value: Option<Vec<String>>,
+    }
+
+    let result = super::from_str("value=abcd&value=def");
+
+    assert_eq!(result, Ok(Form { value: Some(vec!["abcd".to_owned(), "def".to_owned()]) }));
+}
+
+#[test]
 fn deserialize_unit() {
     assert_eq!(super::from_str(""), Ok(()));
     assert_eq!(super::from_str("&"), Ok(()));

--- a/src/de/tests.rs
+++ b/src/de/tests.rs
@@ -51,21 +51,11 @@ fn deserialize_option_vec() {
         value: Option<Vec<String>>,
     }
 
-    let result = super::from_str("value=abcd&value=def");
-
-    assert_eq!(result, Ok(Form { value: Some(vec!["abcd".to_owned(), "def".to_owned()]) }));
-}
-
-#[test]
-fn deserialize_option_vec_empty() {
-    #[derive(Deserialize, PartialEq, Debug)]
-    struct Form {
-        value: Option<Vec<String>>,
-    }
-
-    let result = super::from_str("");
-
-    assert_eq!(result, Ok(Form { value: None }));
+    assert_eq!(
+        super::from_str("value=abc&value=def"),
+        Ok(Form { value: Some(vec!["abc".to_owned(), "def".to_owned()]) })
+    );
+    assert_eq!(super::from_str(""), Ok(Form { value: None }));
 }
 
 #[test]

--- a/src/de/val_or_vec.rs
+++ b/src/de/val_or_vec.rs
@@ -202,6 +202,13 @@ where
         visitor.visit_unit()
     }
 
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_some(self)
+    }
+
     forward_to_part! {
         deserialize_bool,
         deserialize_char,
@@ -220,7 +227,6 @@ where
         deserialize_i64,
         deserialize_f32,
         deserialize_f64,
-        deserialize_option,
         deserialize_identifier,
         deserialize_map,
     }


### PR DESCRIPTION
Ran into this whilst trying to deserialize an optional list of choices in a web app.