### PR TITLE
Skip empty query parameters

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -166,6 +166,10 @@ fn group_entries(parse: UrlEncodedParse<'_>) -> IndexMap<Part<'_>, ValOrVec<Part
     let mut res = IndexMap::new();
 
     for (key, value) in parse {
+        if value.is_empty() {
+            continue;
+        }
+
         match res.entry(Part(key)) {
             Vacant(v) => {
                 v.insert(ValOrVec::Val(Part(value)));

--- a/src/de/tests.rs
+++ b/src/de/tests.rs
@@ -59,6 +59,26 @@ fn deserialize_option_vec() {
 }
 
 #[test]
+fn deserialize_option_no_value() {
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct Form {
+        value: Option<f64>,
+    }
+
+    assert_eq!(super::from_str("value="), Ok(Form { value: None }));
+}
+
+#[test]
+fn deserialize_no_value_err() {
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct Form {
+        value: f64,
+    }
+
+    assert_eq!(super::from_str::<Form>("value=").unwrap_err().to_string(), "missing field `value`");
+}
+
+#[test]
 fn deserialize_unit() {
     assert_eq!(super::from_str(""), Ok(()));
     assert_eq!(super::from_str("&"), Ok(()));


### PR DESCRIPTION
Currently, a key without a value fails to deserialize, even if the field is wrapped in an `Option`. Semantically, no key and a key with an empty value is the same (I think?). This patch filters keys without values before the deserialization starts.

This allows us to deserialize things like `value=` if the `value` is an `Option`. If `value` is not an option, it will fails as expected that it is missing.

Let me know what you think.

I stumbled across this when implementing a form that has optional number fields. It would fail to deserialize with "cannot parse float from an empty string".