### PR TITLE
Support `#[no_std]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,10 @@ rust-version = "1.56"
 bench = false
 
 [features]
-default = ["ryu"]
+default = ["std", "ryu"]
+
+alloc = []
+std = ["alloc"]
 
 [dependencies]
 # Percent encoding and mapping of query string to pair of key-values

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,7 +1,5 @@
 //! Deserialization support for the `application/x-www-form-urlencoded` format.
 
-use std::io::Read;
-
 use form_urlencoded::{parse, Parse as UrlEncodedParse};
 use indexmap::map::{self, IndexMap};
 use serde_core::{
@@ -67,10 +65,11 @@ where
 
 /// Convenience function that reads all bytes from `reader` and deserializes
 /// them with `from_bytes`.
+#[cfg(feature = "std")]
 pub fn from_reader<T, R>(mut reader: R) -> Result<T, Error>
 where
     T: de::DeserializeOwned,
-    R: Read,
+    R: std::io::Read,
 {
     let mut buf = vec![];
     reader

--- a/src/de/part.rs
+++ b/src/de/part.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 
 use serde_core::{
     de::{self, Error as _, IntoDeserializer},

--- a/src/de/tests.rs
+++ b/src/de/tests.rs
@@ -34,6 +34,7 @@ fn deserialize_borrowed_str() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn deserialize_reader() {
     let result = vec![("first".to_owned(), 23), ("last".to_owned(), 42)];
 

--- a/src/de/val_or_vec.rs
+++ b/src/de/val_or_vec.rs
@@ -1,4 +1,5 @@
-use std::{hint::unreachable_unchecked, iter, mem, vec};
+use alloc::vec::{self, Vec};
+use core::{hint::unreachable_unchecked, iter, mem};
 
 use serde_core::de::{
     self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,11 +14,21 @@
     clippy::unseparated_literal_suffix,
     clippy::wildcard_imports
 )]
+#![deny(clippy::std_instead_of_core, clippy::std_instead_of_alloc)]
+#![cfg_attr(not(any(feature = "std", test)), no_std)]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 pub mod de;
 pub mod ser;
 
 #[doc(inline)]
-pub use crate::de::{from_bytes, from_reader, from_str, Deserializer};
+pub use crate::de::{from_bytes, from_str, Deserializer};
+
+#[cfg(feature = "std")]
+#[doc(inline)]
+pub use crate::de::from_reader;
+
 #[doc(inline)]
 pub use crate::ser::{push_to_string, to_string, Serializer};

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -6,7 +6,8 @@ mod pair;
 mod part;
 mod value;
 
-use std::{borrow::Cow, str};
+use alloc::{borrow::Cow, string::String};
+use core::str;
 
 use form_urlencoded::{Serializer as UrlEncodedSerializer, Target as UrlEncodedTarget};
 use serde_core::ser;

--- a/src/ser/error.rs
+++ b/src/ser/error.rs
@@ -1,5 +1,5 @@
-use std::{
-    borrow::Cow,
+use alloc::{borrow::Cow, format};
+use core::{
     error, fmt,
     str::{self, Utf8Error},
 };

--- a/src/ser/key.rs
+++ b/src/ser/key.rs
@@ -1,4 +1,5 @@
-use std::{borrow::Cow, ops::Deref};
+use alloc::{borrow::Cow, string::String};
+use core::ops::Deref;
 
 use serde_core::ser::{self, Serialize};
 

--- a/src/ser/pair.rs
+++ b/src/ser/pair.rs
@@ -1,4 +1,5 @@
-use std::{borrow::Cow, mem};
+use alloc::borrow::Cow;
+use core::mem;
 
 use form_urlencoded::{Serializer as UrlEncodedSerializer, Target as UrlEncodedTarget};
 use serde_core::ser;

--- a/src/ser/part.rs
+++ b/src/ser/part.rs
@@ -1,4 +1,5 @@
-use std::str;
+use alloc::string::{String, ToString};
+use core::str;
 
 use serde_core::ser::{self, Serializer as _};
 

--- a/src/ser/value.rs
+++ b/src/ser/value.rs
@@ -1,4 +1,5 @@
-use std::str;
+use alloc::string::String;
+use core::str;
 
 use form_urlencoded::{Serializer as UrlEncodedSerializer, Target as UrlEncodedTarget};
 use serde_core::ser::{Serialize, SerializeSeq};


### PR DESCRIPTION
- [x] `no_std` w/ `alloc`
- [ ] (future) `no_std` w/out `alloc`
  - caller-allocated buffers?
  - heapless?

Alternative stratgey: break out into a new `serde_html_form_core`-esque crate.