### PR TITLE
Implement optional "empty is `Some`" behavior

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -36,7 +36,7 @@ pub fn from_bytes<'de, T>(input: &'de [u8]) -> Result<T, Error>
 where
     T: de::Deserialize<'de>,
 {
-    T::deserialize(Deserializer::from_bytes(input))
+    T::deserialize(Deserializer::<false>::from_bytes(input))
 }
 
 /// Deserializes a `application/x-www-form-urlencoded` value from a `&str`.
@@ -72,11 +72,11 @@ where
 ///
 /// * Everything else but `deserialize_seq` and `deserialize_seq_fixed_size`
 ///   defers to `deserialize`.
-pub struct Deserializer<'de> {
+pub struct Deserializer<'de, const EMPTY_IS_SOME: bool = false> {
     inner: UrlEncodedParse<'de>,
 }
 
-impl<'de> Deserializer<'de> {
+impl<'de, const EMPTY_IS_SOME: bool> Deserializer<'de, EMPTY_IS_SOME> {
     /// Returns a new `Deserializer`.
     pub fn new(parse: UrlEncodedParse<'de>) -> Self {
         Deserializer { inner: parse }
@@ -88,7 +88,7 @@ impl<'de> Deserializer<'de> {
     }
 }
 
-impl<'de> de::Deserializer<'de> for Deserializer<'de> {
+impl<'de, const EMPTY_IS_SOME: bool> de::Deserializer<'de> for Deserializer<'de, EMPTY_IS_SOME> {
     type Error = Error;
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -102,21 +102,22 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
     where
         V: de::Visitor<'de>,
     {
-        visitor.visit_map(MapDeserializer::new(group_entries(self.inner).into_iter()))
+        visitor
+            .visit_map(MapDeserializer::new(group_entries::<EMPTY_IS_SOME>(self.inner).into_iter()))
     }
 
     fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: de::Visitor<'de>,
     {
-        visitor.visit_seq(MapDeserializer::new(PartIterator(self.inner)))
+        visitor.visit_seq(MapDeserializer::new(PartIterator::<EMPTY_IS_SOME>(self.inner)))
     }
 
     fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: de::Visitor<'de>,
     {
-        let deserializer = MapDeserializer::new(PartIterator(self.inner));
+        let deserializer = MapDeserializer::new(PartIterator::<EMPTY_IS_SOME>(self.inner));
         deserializer.end()?;
         visitor.visit_unit()
     }
@@ -156,17 +157,19 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
     }
 }
 
-struct PartIterator<'de>(UrlEncodedParse<'de>);
+struct PartIterator<'de, const EMPTY_IS_SOME: bool>(UrlEncodedParse<'de>);
 
-impl<'de> Iterator for PartIterator<'de> {
-    type Item = (Part<'de>, Part<'de>);
+impl<'de, const EMPTY_IS_SOME: bool> Iterator for PartIterator<'de, EMPTY_IS_SOME> {
+    type Item = (Part<'de, EMPTY_IS_SOME>, Part<'de, EMPTY_IS_SOME>);
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next().map(|(k, v)| (Part(k), Part(v)))
     }
 }
 
-fn group_entries(parse: UrlEncodedParse<'_>) -> IndexMap<Part<'_>, ValOrVec<Part<'_>>> {
+fn group_entries<const EMPTY_IS_SOME: bool>(
+    parse: UrlEncodedParse<'_>,
+) -> IndexMap<Part<'_, EMPTY_IS_SOME>, ValOrVec<Part<'_, EMPTY_IS_SOME>>> {
     use map::Entry::*;
 
     let mut res = IndexMap::new();
@@ -183,6 +186,61 @@ fn group_entries(parse: UrlEncodedParse<'_>) -> IndexMap<Part<'_>, ValOrVec<Part
     }
 
     res
+}
+
+/// Deserialization with empty strings treated as `Some("")` instead of `None`.
+///
+/// This module provides the same API as the parent module, but with different
+/// behavior for empty values: `foo=` deserializes to `Some("")` for `Option<String>`
+/// instead of `None`.
+///
+/// # Example
+///
+/// ```
+/// use serde::Deserialize;
+///
+/// #[derive(Debug, PartialEq, Deserialize)]
+/// struct Form {
+///     value: Option<String>,
+/// }
+///
+/// // Default behavior: empty string becomes None
+/// assert_eq!(
+///     serde_html_form::from_str::<Form>("value="),
+///     Ok(Form { value: None })
+/// );
+///
+/// // With empty_is_some: empty string becomes Some("")
+/// assert_eq!(
+///     serde_html_form::empty_is_some::from_str::<Form>("value="),
+///     Ok(Form { value: Some("".to_owned()) })
+/// );
+/// ```
+pub mod empty_is_some {
+    use super::{de, Error};
+
+    /// A type alias for the deserializer with `EMPTY_IS_SOME = true`.
+    pub type Deserializer<'de> = super::Deserializer<'de, true>;
+
+    /// Deserializes a `application/x-www-form-urlencoded` value from a `&[u8]`.
+    ///
+    /// Empty values are deserialized as `Some("")` for `Option<String>` fields.
+    pub fn from_bytes<'de, T>(input: &'de [u8]) -> Result<T, Error>
+    where
+        T: de::Deserialize<'de>,
+    {
+        T::deserialize(Deserializer::from_bytes(input))
+    }
+
+    /// Deserializes a `application/x-www-form-urlencoded` value from a `&str`.
+    ///
+    /// Empty values are deserialized as `Some("")` for `Option<String>` fields.
+    pub fn from_str<'de, T>(input: &'de str) -> Result<T, Error>
+    where
+        T: de::Deserialize<'de>,
+    {
+        from_bytes(input.as_bytes())
+    }
 }
 
 #[cfg(test)]

--- a/src/de/part.rs
+++ b/src/de/part.rs
@@ -8,9 +8,9 @@ use serde_core::{
 use super::Error;
 
 #[derive(PartialEq, PartialOrd, Eq, Ord, Hash)]
-pub(super) struct Part<'de>(pub Cow<'de, str>);
+pub(super) struct Part<'de, const EMPTY_IS_SOME: bool = false>(pub Cow<'de, str>);
 
-impl<'de> IntoDeserializer<'de> for Part<'de> {
+impl<'de, const EMPTY_IS_SOME: bool> IntoDeserializer<'de> for Part<'de, EMPTY_IS_SOME> {
     type Deserializer = Self;
 
     fn into_deserializer(self) -> Self::Deserializer {
@@ -33,7 +33,7 @@ macro_rules! forward_parsed_value {
     }
 }
 
-impl<'de> de::Deserializer<'de> for Part<'de> {
+impl<'de, const EMPTY_IS_SOME: bool> de::Deserializer<'de> for Part<'de, EMPTY_IS_SOME> {
     type Error = Error;
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -50,7 +50,7 @@ impl<'de> de::Deserializer<'de> for Part<'de> {
     where
         V: de::Visitor<'de>,
     {
-        if self.0.is_empty() {
+        if !EMPTY_IS_SOME && self.0.is_empty() {
             visitor.visit_none()
         } else {
             visitor.visit_some(self)
@@ -118,7 +118,7 @@ impl<'de> de::Deserializer<'de> for Part<'de> {
     }
 }
 
-impl<'de> de::EnumAccess<'de> for Part<'de> {
+impl<'de, const EMPTY_IS_SOME: bool> de::EnumAccess<'de> for Part<'de, EMPTY_IS_SOME> {
     type Error = Error;
     type Variant = UnitOnlyVariantAccess;
 
@@ -131,9 +131,9 @@ impl<'de> de::EnumAccess<'de> for Part<'de> {
     }
 }
 
-struct PartSeqAccess<'de>(Option<Part<'de>>);
+struct PartSeqAccess<'de, const EMPTY_IS_SOME: bool>(Option<Part<'de, EMPTY_IS_SOME>>);
 
-impl<'de> de::SeqAccess<'de> for PartSeqAccess<'de> {
+impl<'de, const EMPTY_IS_SOME: bool> de::SeqAccess<'de> for PartSeqAccess<'de, EMPTY_IS_SOME> {
     type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,6 @@ pub mod de;
 pub mod ser;
 
 #[doc(inline)]
-pub use crate::de::{from_bytes, from_str, Deserializer};
+pub use crate::de::{empty_is_some, from_bytes, from_str, Deserializer};
 #[doc(inline)]
 pub use crate::ser::{push_to_string, to_string, Serializer};


### PR DESCRIPTION
This is another idea/attempt of solving https://github.com/jplatte/serde_html_form/issues/13.

This PR introduces an internal const generic `EMPTY_IS_SOME` parameter, that determines if empty strings should be treated as `None` or `Some("")`. The behavior of `from_bytes()` and `from_str()` stays the same, but an additional `empty_is_some` module with the same fns is introduced, that allows users to choose the alternative behavior.

Ideally we would use an enum instead of a bool, but unfortunately enums are not allowed in const generics (yet?). An alternative is using marker types, but that requires use to put `PhantomData` everywhere and isn't much more readable in the end.