### PR TITLE
Treat empty values as empty values, not None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
   - This was a deviation from `serde_urlencoded`, which is now reverted
   - This means when deserializing to a catch-all type like `serde_json::Value`, you will now
     get an `Object` instead of an `Array`
+- Change deserialization of optional values to treat empty values (like in `foo=&bar=`)
+  as `Some(_)` rather than `None`, _except_ for `Option<bool>` and `Option<{number}>` (for
+  specific number types that are either builtin or part of the standard library)
+  - This reverts the main change from v0.1.1 while still allowing simple optional number fields to
+    work
 - Remove `de::from_reader`
 
 # 0.2.8

--- a/src/de.rs
+++ b/src/de.rs
@@ -11,6 +11,7 @@ use serde_core::{
 pub use serde_core::de::value::Error;
 
 mod part;
+mod utils;
 mod val_or_vec;
 
 use self::{part::Part, val_or_vec::ValOrVec};

--- a/src/de/utils.rs
+++ b/src/de/utils.rs
@@ -1,0 +1,36 @@
+use std::{any::TypeId, marker::PhantomData, mem};
+
+/// Produces type IDs that are compatible with `TypeId::of::<T>`, but without
+/// `T: 'static` bound.
+///
+/// This function must be used with extreme discretion, as no lifetime checking
+/// is done. Meaning, this function returns the same `TypeId` for `Struct<'a>`
+/// and `Struct<'b>`, regardless of the relationship of `'a` and `'b`.
+///
+/// It is however a safe function since `TypeId` itself doesn't allow one to do
+/// anything dangerous in safe code. In this crate, it's only used to specialize
+/// behavior based on the type, there is no transmuting going on outside of this
+/// function.
+pub(crate) fn non_static_type_id<T: ?Sized>() -> TypeId {
+    // Copied from the castaway crate, Copyright (c) 2021 Stephen M. Coakley
+
+    trait NonStaticAny {
+        fn get_type_id(&self) -> TypeId
+        where
+            Self: 'static;
+    }
+
+    impl<T: ?Sized> NonStaticAny for PhantomData<T> {
+        fn get_type_id(&self) -> TypeId
+        where
+            Self: 'static,
+        {
+            TypeId::of::<T>()
+        }
+    }
+
+    let phantom_data = PhantomData::<T>;
+    NonStaticAny::get_type_id(unsafe {
+        mem::transmute::<&dyn NonStaticAny, &(dyn NonStaticAny + 'static)>(&phantom_data)
+    })
+}


### PR DESCRIPTION
… except for booleans or numbers, where it's very commonly needed to treat empty values as None.

Closes #13.