### PR TITLE
Add ahash as no_std hasher

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,11 +43,17 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test
 
-  test-min-features:
-    name: Build with minimal features
+  test-ahash:
+    name: Build no_std
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-none
       - uses: Swatinem/rust-cache@v2
-      - run: cargo build --no-default-features --features std
+      - run: >
+          cargo build
+          --no-default-features
+          --features ahash/compile-time-rng
+          --target x86_64-unknown-none

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,20 @@ bench = false
 
 [features]
 default = ["ryu", "std"]
+# Use ahash for the internal `IndexMap`s that `serde_html_form` creates
+# to buffer inputs in some cases. None of `ahash`s features are enabled by this
+# crate. Please depend on ahash yourself and choose the appropriate rng feature
+# for your use case such that this crate compiles.
+#
+# This feature has no effect if the `std` feature is also enabled.
+ahash = ["dep:ahash"]
 # Use std's default hasher for the internal `IndexMap`s that `serde_html_form`
 # creates to buffer inputs in some cases.
-#
-# Currently, building without this feature is not supported.
 std = []
 
 [dependencies]
+# Alternative hasher for IndexMap that doesn't require std and is faster
+ahash = { version = "0.8.12", optional = true, default-features = false }
 # Percent encoding and mapping of query string to pair of key-values
 form_urlencoded = { version = "1.0.1", default-features = false, features = ["alloc"] }
 # Used for internal buffering during deserialization

--- a/src/de.rs
+++ b/src/de.rs
@@ -170,8 +170,11 @@ impl<'de> Iterator for PartIterator<'de> {
 #[cfg(feature = "std")]
 type RandomState = std::hash::RandomState;
 
-#[cfg(not(feature = "std"))]
-type RandomState = compile_error!("the `std` feature is currently required");
+#[cfg(all(feature = "ahash", not(feature = "std")))]
+type RandomState = ahash::RandomState;
+
+#[cfg(not(any(feature = "std", feature = "ahash")))]
+type RandomState = compile_error!("one of the features `std`, `ahash` must be enabled");
 
 fn group_entries(
     parse: UrlEncodedParse<'_>,
@@ -181,7 +184,7 @@ fn group_entries(
     let mut res = IndexMap::default();
 
     // silence unhelpful errors when we hit the compile_error! above anyways
-    #[cfg(feature = "std")]
+    #[cfg(any(feature = "std", feature = "ahash"))]
     for (key, value) in parse {
         match res.entry(Part(key)) {
             Vacant(v) => {


### PR DESCRIPTION
@owenthewizard I got rid of all the plain unnecessary std dependencies in #30. However, the internal `indexmap` remains and needs a hasher. Does this ahash-based solution work for your use case? Building succeeds for the x86_64-unknown-none target when enabling ahashs compile-time-rng feature at least (see CI changes).